### PR TITLE
在垃圾分类页面添加了快速选择模型提供商的下拉选框

### DIFF
--- a/components/control/SettingComboBox.qml
+++ b/components/control/SettingComboBox.qml
@@ -13,8 +13,7 @@ ComboBox {
     background: Rectangle {
         border.width: 1
         border.color: "#d0d0d5"
-        implicitWidth: parent.width
-        implicitHeight: parent.height
+        anchors.fill: parent
         radius: 6
         color: root.theme.card
     }

--- a/components/pages/GarbagePage.qml
+++ b/components/pages/GarbagePage.qml
@@ -5,6 +5,7 @@ import Qt5Compat.GraphicalEffects
 
 import "../control"
 import "../theme"
+import "../settings"
 
 Item {
     id: root
@@ -40,7 +41,7 @@ Item {
             }
 
             Text {
-                id:trashImagePreviewTitle
+                id: trashImagePreviewTitle
                 text: "上传图片"
                 color: root.theme.text
                 font.pixelSize: 24
@@ -50,6 +51,22 @@ Item {
                 anchors.verticalCenter: trashImagePreviewIcon.verticalCenter
             }
 
+            Item {
+                id: fastProviderSetting
+                width: 120
+                height: 40
+                anchors.right: trashImagePreviewZone.right
+                anchors.rightMargin: 30
+                anchors.verticalCenter: trashImagePreviewIcon.verticalCenter
+                SettingComboBox {
+                    model: ["本地模型","百度云"]
+                    currentIndex: model.indexOf(iniFileHandler["provider"])
+                    onCurrentValueChanged: {
+                        if (currentValue !== iniFileHandler["provider"])
+                            iniFileHandler["provider"] = currentValue
+                    }
+                }
+            }
 
             Rectangle {
                 id: trashImagePreview

--- a/components/settings/SettingItem.qml
+++ b/components/settings/SettingItem.qml
@@ -14,10 +14,10 @@ Rectangle {
     border.color: root.theme.borderColor
     radius: 8
 
-    property string text1
-    property string text2
-    property string ctrlType
-    property string iconSource
+    property string text1: ""
+    property string text2: ""
+    property string ctrlType: ""
+    property string iconSource: ""
 
     property var comboboxModel: []
     property string textFieldTips: ""


### PR DESCRIPTION
1.在垃圾分类页面添加了快速选择模型提供商的下拉选框
2.更改了`SettingComboBox.qml`的填充逻辑，现在在其他地方不会出现循环绑定了
3.给`SettingItem.qml`添加了默认情况